### PR TITLE
"SET NAMES utf8mb4;"をデータセット生成SQLに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ mysql> GRANT ALL on *.* TO isucon@'localhost';
 初期データ投入
 
 ```sh
-zcat ~/isubata/bench/isucon7q-initial-dataset.sql.gz | sudo mysql --default-character-set=utf8 isubata
+zcat ~/isubata/bench/isucon7q-initial-dataset.sql.gz | sudo mysql isubata
 ```
 
 デフォルトだとTCPが127.0.0.1しかbindしてないので、複数台構成に対応するには

--- a/bench/src/bench/dataset.go
+++ b/bench/src/bench/dataset.go
@@ -247,6 +247,7 @@ func GenerateInitialDataSetSQL(outputPath string) {
 	w := gzip.NewWriter(outFile)
 	defer w.Close()
 
+	fbadf(w, "SET NAMES utf8mb4;")
 	fbadf(w, "BEGIN;")
 
 	rnd := rand.New(rand.NewSource(3656))

--- a/provisioning/allinone/roles/mysql/tasks/main.yml
+++ b/provisioning/allinone/roles/mysql/tasks/main.yml
@@ -76,7 +76,7 @@
   #when: isubata_repository.changed
 
 - name: Import benchmark data
-  shell: zcat isucon7q-initial-dataset.sql.gz | mysql --default-character-set=utf8 isubata
+  shell: zcat isucon7q-initial-dataset.sql.gz | mysql isubata
   args:
     chdir: /home/isucon/isubata/bench/
   become: yes


### PR DESCRIPTION
@ISUCON運営/ボランティアの皆さま

初期データ作成のためのSQL内で utf8mb4 を明示するようにしました。

背景としては、非公式の [Docker環境](https://github.com/matsuu/docker-isucon/tree/master/isucon7-qualifier) でISUCONを試そうとしたところ、mysql client の charset が指定されておらずSQLから作成されたデータが文字化けしていたからなのですが、公式の provisioning でもSQLを流す際に `--default-character-set` を指定しており、SQL文のなかで指定した方が汎用性が高いと思ったため、こちらの公式リポジトリのほうにプルリクエストをお送りさせて頂きました。

もしご迷惑でしたらこのままCloseしてください。よろしくお願いいたします。