### PR TITLE
Ansibleの修正

### DIFF
--- a/provisioning/allinone/roles/python/files/etc/systemd/system/isubata.python.service
+++ b/provisioning/allinone/roles/python/files/etc/systemd/system/isubata.python.service
@@ -5,7 +5,7 @@ Description = isucon7 qualifier main application in python
 WorkingDirectory=/home/isucon/isubata/webapp/python
 EnvironmentFile=/home/isucon/env.sh
 
-ExecStart = /home/isucon/local/python/bin/gunicorn --workers=4 --threads=4 app:app -b '127.0.0.1:5000'
+ExecStart = /home/isucon/isubata/webapp/python/venv/bin/gunicorn --workers=4 --threads=4 app:app -b '127.0.0.1:5000'
 
 Restart   = always
 Type      = simple

--- a/provisioning/allinone/roles/python/tasks/main.yml
+++ b/provisioning/allinone/roles/python/tasks/main.yml
@@ -47,6 +47,21 @@
   notify:
     - daemon-reload
 
+- name: Install Python lib
+  apt:
+    pkg: "{{ item }}"
+  become: yes
+  with_items:
+    - python3-venv
+    - python3-dev
+
+- name: Exec setup.sh
+  command: sh setup.sh 
+  args:
+    chdir: /home/isucon/isubata/webapp/python
+  become: yes
+  become_user: isucon
+
 - name: Enable and start isubata.python
   systemd:
     name: isubata.python


### PR DESCRIPTION
ExecStartについては、venvを使っている為そこのパスに変更
pythonのtasksについては、足りていないライブラリと初期実装動かすための変更になります。
(Ansible叩いただけでは動かない)